### PR TITLE
Missing extension.toml key.

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -1,6 +1,7 @@
 id = "base16"
 name = "base16"
 version = "0.1.1"
+schema_version = 1
 authors = [
     "Brooks Swinnerton <bswinnerton@gmail.com>",
     "Tim Chmielecki <me@timcki.com>",


### PR DESCRIPTION
- This was missing from: https://github.com/bswinnerton/base16-zed/pull/5
- And is blocking: https://github.com/zed-industries/extensions/pull/1552