### PR TITLE
Fix incorrectly mapped light themes

### DIFF
--- a/themes/base16-brushtrees.json
+++ b/themes/base16-brushtrees.json
@@ -5,7 +5,7 @@
   "themes": [
     {
       "name": "Base16 Brush Trees",
-      "appearance": "dark",
+      "appearance": "light",
       "style": {
         "border": "#b0c5c8",
         "border.variant": "#b0c5c8",

--- a/themes/base16-catppuccin-latte.json
+++ b/themes/base16-catppuccin-latte.json
@@ -5,7 +5,7 @@
   "themes": [
     {
       "name": "Base16 Catppuccin Latte",
-      "appearance": "dark",
+      "appearance": "light",
       "style": {
         "border": "#ccd0da",
         "border.variant": "#ccd0da",

--- a/themes/base16-cupcake.json
+++ b/themes/base16-cupcake.json
@@ -5,7 +5,7 @@
   "themes": [
     {
       "name": "Base16 Cupcake",
-      "appearance": "dark",
+      "appearance": "light",
       "style": {
         "border": "#d8d5dd",
         "border.variant": "#d8d5dd",

--- a/themes/base16-cupertino.json
+++ b/themes/base16-cupertino.json
@@ -5,7 +5,7 @@
   "themes": [
     {
       "name": "Base16 Cupertino",
-      "appearance": "dark",
+      "appearance": "light",
       "style": {
         "border": "#c0c0c0",
         "border.variant": "#c0c0c0",

--- a/themes/base16-da-one-paper.json
+++ b/themes/base16-da-one-paper.json
@@ -5,7 +5,7 @@
   "themes": [
     {
       "name": "Base16 Da One Paper",
-      "appearance": "dark",
+      "appearance": "light",
       "style": {
         "border": "#888888",
         "border.variant": "#888888",

--- a/themes/base16-da-one-white.json
+++ b/themes/base16-da-one-white.json
@@ -5,7 +5,7 @@
   "themes": [
     {
       "name": "Base16 Da One White",
-      "appearance": "dark",
+      "appearance": "light",
       "style": {
         "border": "#888888",
         "border.variant": "#888888",

--- a/themes/base16-dirtysea.json
+++ b/themes/base16-dirtysea.json
@@ -5,7 +5,7 @@
   "themes": [
     {
       "name": "Base16 dirtysea",
-      "appearance": "dark",
+      "appearance": "light",
       "style": {
         "border": "#d0d0d0",
         "border.variant": "#d0d0d0",

--- a/themes/base16-emil.json
+++ b/themes/base16-emil.json
@@ -5,7 +5,7 @@
   "themes": [
     {
       "name": "Base16 emil",
-      "appearance": "dark",
+      "appearance": "light",
       "style": {
         "border": "#9e9eaf",
         "border.variant": "#9e9eaf",

--- a/themes/base16-fruit-soda.json
+++ b/themes/base16-fruit-soda.json
@@ -5,7 +5,7 @@
   "themes": [
     {
       "name": "Base16 Fruit Soda",
-      "appearance": "dark",
+      "appearance": "light",
       "style": {
         "border": "#d8d5d5",
         "border.variant": "#d8d5d5",

--- a/themes/base16-github.json
+++ b/themes/base16-github.json
@@ -5,7 +5,7 @@
   "themes": [
     {
       "name": "Base16 Github",
-      "appearance": "dark",
+      "appearance": "light",
       "style": {
         "border": "#c8c8fa",
         "border.variant": "#c8c8fa",

--- a/themes/base16-gruvbox-light-hard.json
+++ b/themes/base16-gruvbox-light-hard.json
@@ -5,7 +5,7 @@
   "themes": [
     {
       "name": "Base16 Gruvbox light, hard",
-      "appearance": "dark",
+      "appearance": "light",
       "style": {
         "border": "#d5c4a1",
         "border.variant": "#d5c4a1",

--- a/themes/base16-gruvbox-light-medium.json
+++ b/themes/base16-gruvbox-light-medium.json
@@ -5,7 +5,7 @@
   "themes": [
     {
       "name": "Base16 Gruvbox light, medium",
-      "appearance": "dark",
+      "appearance": "light",
       "style": {
         "border": "#d5c4a1",
         "border.variant": "#d5c4a1",

--- a/themes/base16-gruvbox-light-soft.json
+++ b/themes/base16-gruvbox-light-soft.json
@@ -5,7 +5,7 @@
   "themes": [
     {
       "name": "Base16 Gruvbox light, soft",
-      "appearance": "dark",
+      "appearance": "light",
       "style": {
         "border": "#d5c4a1",
         "border.variant": "#d5c4a1",

--- a/themes/base16-gruvbox-material-light-hard.json
+++ b/themes/base16-gruvbox-material-light-hard.json
@@ -5,7 +5,7 @@
   "themes": [
     {
       "name": "Base16 Gruvbox Material Light, Hard",
-      "appearance": "dark",
+      "appearance": "light",
       "style": {
         "border": "#e0cfa9",
         "border.variant": "#e0cfa9",

--- a/themes/base16-gruvbox-material-light-medium.json
+++ b/themes/base16-gruvbox-material-light-medium.json
@@ -5,7 +5,7 @@
   "themes": [
     {
       "name": "Base16 Gruvbox Material Light, Medium",
-      "appearance": "dark",
+      "appearance": "light",
       "style": {
         "border": "#d5c4a1",
         "border.variant": "#d5c4a1",

--- a/themes/base16-gruvbox-material-light-soft.json
+++ b/themes/base16-gruvbox-material-light-soft.json
@@ -5,7 +5,7 @@
   "themes": [
     {
       "name": "Base16 Gruvbox Material Light, Soft",
-      "appearance": "dark",
+      "appearance": "light",
       "style": {
         "border": "#c9b99a",
         "border.variant": "#c9b99a",

--- a/themes/base16-rose-pine-dawn.json
+++ b/themes/base16-rose-pine-dawn.json
@@ -5,7 +5,7 @@
   "themes": [
     {
       "name": "Base16 Rosé Pine Dawn",
-      "appearance": "dark",
+      "appearance": "light",
       "style": {
         "border": "#f2e9de",
         "border.variant": "#f2e9de",

--- a/themes/base16-sagelight.json
+++ b/themes/base16-sagelight.json
@@ -5,7 +5,7 @@
   "themes": [
     {
       "name": "Base16 Sagelight",
-      "appearance": "dark",
+      "appearance": "light",
       "style": {
         "border": "#d8d8d8",
         "border.variant": "#d8d8d8",

--- a/themes/base16-sakura.json
+++ b/themes/base16-sakura.json
@@ -5,7 +5,7 @@
   "themes": [
     {
       "name": "Base16 Sakura",
-      "appearance": "dark",
+      "appearance": "light",
       "style": {
         "border": "#e0ccd1",
         "border.variant": "#e0ccd1",

--- a/themes/base16-selenized-white.json
+++ b/themes/base16-selenized-white.json
@@ -5,7 +5,7 @@
   "themes": [
     {
       "name": "Base16 selenized-white",
-      "appearance": "dark",
+      "appearance": "light",
       "style": {
         "border": "#cdcdcd",
         "border.variant": "#cdcdcd",

--- a/themes/base16-shapeshifter.json
+++ b/themes/base16-shapeshifter.json
@@ -5,7 +5,7 @@
   "themes": [
     {
       "name": "Base16 Shapeshifter",
-      "appearance": "dark",
+      "appearance": "light",
       "style": {
         "border": "#ababab",
         "border.variant": "#ababab",

--- a/themes/base16-still-alive.json
+++ b/themes/base16-still-alive.json
@@ -5,7 +5,7 @@
   "themes": [
     {
       "name": "Base16 Still Alive",
-      "appearance": "dark",
+      "appearance": "light",
       "style": {
         "border": "#fff018",
         "border.variant": "#fff018",

--- a/themes/base16-tomorrow.json
+++ b/themes/base16-tomorrow.json
@@ -5,7 +5,7 @@
   "themes": [
     {
       "name": "Base16 Tomorrow",
-      "appearance": "dark",
+      "appearance": "light",
       "style": {
         "border": "#d6d6d6",
         "border.variant": "#d6d6d6",


### PR DESCRIPTION
I noticed that there were a few light themes that were incorrectly mapped as dark themes. This would lead to the terminal foreground colors being inverted and impossible to read.

I believe I caught all the themes in question.